### PR TITLE
Weiterleitungs-Link aus .env-Datei lesen

### DIFF
--- a/backend/src/auth/sso.ts
+++ b/backend/src/auth/sso.ts
@@ -2,7 +2,7 @@ import {Issuer} from 'openid-client';
 import {NextFunction, Request, Response} from 'express';
 import {deserialize, serialize} from './session';
 import {clearSessionCookie, getSessionCookie, setSessionCookie,} from './cookie';
-import {iservConnectionError, iservLink, redirectLink} from './staticAuthStrings';
+import {iservConnectionError, iservLink} from './staticAuthStrings';
 
 
 /*
@@ -25,7 +25,7 @@ export async function initialize(
          const client = new issuer.Client({
              client_id: process.env.OAUTH_CLIENT_ID!,
              client_secret: process.env.OAUTH_CLIENT_SECRET!,
-             redirect_uris: [redirectLink],
+             redirect_uris: [process.env.REDIRECT_LINK!],
              response_types: ['code'],
          });
 

--- a/backend/src/auth/staticAuthStrings.ts
+++ b/backend/src/auth/staticAuthStrings.ts
@@ -1,6 +1,5 @@
 // Links
 export const iservLink = 'https://kant-gymnasium.de/iserv/public';
-export const redirectLink = 'http://einschreibung.kant-gymnasium.de:5000/auth/callback';
 
 // Errors
 export const iservConnectToLoginError = 'An error occurred while trying to connect to the iserv login page';

--- a/backend/src/routing/controllers/Auth.ts
+++ b/backend/src/routing/controllers/Auth.ts
@@ -1,7 +1,6 @@
 import {NextFunction, Request, Response} from 'express';
 import {
     iservConnectToLoginError,
-    redirectLink,
     iservRevokeTokenError,
     iservRetrieveUserDataError
 } from '../../auth/staticAuthStrings';
@@ -14,7 +13,6 @@ export default class Auth {
     static async GETlogin(req: Request, res: Response, next: NextFunction): Promise<void> {
         {
             try {
-                console.log('login');
                 const backToPath = req.query.backTo as string;
                 const state = serializeAuthState({ backToPath });
                 const authUrl = req.app.authClient?.authorizationUrl({
@@ -29,9 +27,10 @@ export default class Auth {
                 }
             } catch (e) {
                 console.error(iservConnectToLoginError, e);
+                res.redirect('/');
             }
 
-            next();
+
         }
     }
 
@@ -47,7 +46,7 @@ export default class Auth {
             const params = client!.callbackParams(req);
 
             const tokenSet = await client!.callback(
-                redirectLink,
+                process.env.REDIRECT_LINK,
                 params,
                 { state }
             );


### PR DESCRIPTION
- Weiterleitung auf Startseite, falls Verbindung zur IServ Login-Seite fehlschlägt