### PR TITLE
18-api-api-abitur-setapprovalstate-post

### DIFF
--- a/backend/src/routing/controllers/api/Abitur.ts
+++ b/backend/src/routing/controllers/api/Abitur.ts
@@ -1,23 +1,27 @@
 import { Request, Response } from 'express';
-import { insertData } from '../../../db/dbAccessor';
-import { validationResult } from 'express-validator';
+import {updateData, insertData, defaultInsertCallback, defaultUpdateCallback} from '../../../db/dbAccessor';
+import rejectWhenValidationsFail from '../../validators/rejectWhenValidationsFail';
 
 export default class Abitur {
+
     static GETtest(req: Request, res: Response): void {
         res.send('abi-test');
     }
-    static POSTapplyForTopic(req: Request, res: Response): void {
 
-        if (!validationResult(req).isEmpty()) {
-            res.status(400).json(validationResult(req).mapped());
-            return;
-        }
+    static POSTapplyForTopic(req: Request, res: Response): void {
+        if (rejectWhenValidationsFail(req, res)) return;
 
         const {responsibleTeacherId, art, bezugsfachId, partnerStudentId, referenzfachId, topic} = req.body;
         const sql = 'INSERT INTO abiturpruefungen (betreuendeLehrkraftID, art, bezugsfachID, partnerStudentId, referenzfachID, thema) VALUES (?,?,?,?,?,?)';
-        insertData(sql, [responsibleTeacherId, art, bezugsfachId, partnerStudentId, referenzfachId, topic], (id, err) => {
-            if (err) res.status(500).json(err.name);
-            else res.status(200).json({examId: id});
-        });
+        insertData(sql, [responsibleTeacherId, art, bezugsfachId, partnerStudentId, referenzfachId, topic], defaultInsertCallback(res));
+    }
+
+    static POSTsetApprovalState(req: Request, res: Response): void {
+        if (rejectWhenValidationsFail(req, res)) return;
+
+        const { examId, approved } = req.body;
+        const reason = approved ? null : req.body.reason;
+        const sql = 'UPDATE abiturpruefungen SET genehmigt = ?, ablehnungsgrund = ? WHERE id = ?';
+        updateData(sql, [approved, reason, examId], defaultUpdateCallback(res));
     }
 }

--- a/backend/src/routing/routes/api/abitur.ts
+++ b/backend/src/routing/routes/api/abitur.ts
@@ -6,7 +6,8 @@ export default (): Router => {
     const router = Router();
 
     router.get('/test', Abitur.GETtest);
-    router.post('/applyForTopic', AbiturValidators.POSTApplyForTopic, Abitur.POSTapplyForTopic);
+    router.post('/applyForTopic', AbiturValidators.POSTapplyForTopic, Abitur.POSTapplyForTopic);
+    router.post('/setApprovalState', AbiturValidators.POSTsetApprovalState, Abitur.POSTsetApprovalState);
 
     return router;
 };

--- a/backend/src/routing/validators/api/abitur.ts
+++ b/backend/src/routing/validators/api/abitur.ts
@@ -1,12 +1,19 @@
 import { body } from 'express-validator';
 
 export default class AbiturValidators {
-    static POSTApplyForTopic = [
+    static POSTapplyForTopic = [
         body('responsibleTeacherId').isInt(),
         body('art').isString().isIn(['BLL', 'PP']),
         body('bezugsfachId').isInt(),
         body('partnerStudentId').isInt(),
         body('referenzfachId').isInt(),
         body('topic').isString().trim(),
-    ]
+    ];
+    static POSTsetApprovalState = [
+        body('examId').isInt(),
+        body('approved').isBoolean(),
+        // eslint disabled, weil die typisierung von der funktion im if nur mit any nachzubilden ist
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        body('reason').if((value: any, {req}: any) => !req.body.approved).isString(),
+    ];
 }

--- a/backend/src/routing/validators/rejectWhenValidationsFail.ts
+++ b/backend/src/routing/validators/rejectWhenValidationsFail.ts
@@ -1,0 +1,12 @@
+import {Request, Response} from 'express';
+import {validationResult} from 'express-validator';
+
+const rejectWhenValidationsFail = (req: Request, res: Response): boolean => {
+    if (!validationResult(req).isEmpty()) {
+        res.status(400).json(validationResult(req).mapped());
+        return true;
+    }
+    return false;
+};
+
+export default rejectWhenValidationsFail;

--- a/dokumentation/db/Kant-Schnittstellen.txt
+++ b/dokumentation/db/Kant-Schnittstellen.txt
@@ -133,7 +133,7 @@ api/ag/delete/{agId} (POST) (oder GET?)
 2 Schüler beantragen Thema
 /api/abitur/applyForTopic (POST)
 	{Int partnerStudentId, String art (one of ['PP', 'BLL']), Int referenzfachId, Int bezugsfachId, Int responsibleTeacherId, String topic}
-	->{Int examId}
+	->{Int id}
 
 7 admin ändert Daten
 /api/abitur/editData/{Int studentId} (POST)


### PR DESCRIPTION
Abitur.ts:
- POSTsetApprovalState einbinden
- reason auf null setzen wenn approved, da der ablehnungsgrung nicht benötigt wird, wenn nicht abgelehnt wurde
- reason muss nur ein String sein wenn approved false ist, da sonst kein Grund benötigt wird

dbAccessor.ts:
- default callbacks für updateData und insertData erstellen
- updateData erstellen

Kant-Schnittstellen.txt:
- schnittstellenbeschreibung anpassen, damit der default callback für insertData passt

rejectWhenValidationsFail.ts:
- die überprüfung ob die Validierungen fehlschlagen in eine eigene Datei auslagern