### PR TITLE
49-submitdates-ergänzen-in-schnittstellen-und-db:

### DIFF
--- a/backend/migrations/20211201142913-tutorHinzufuegenAbitur.js
+++ b/backend/migrations/20211201142913-tutorHinzufuegenAbitur.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20211201142913-tutorHinzufuegenAbitur-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20211201142913-tutorHinzufuegenAbitur-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/backend/migrations/sqls/20211201142913-tutorHinzufuegenAbitur-down.sql
+++ b/backend/migrations/sqls/20211201142913-tutorHinzufuegenAbitur-down.sql
@@ -1,0 +1,26 @@
+CREATE TABLE abitur_temp (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    art VARCHAR,
+    partnerStudentName VARCHAR,
+    updatedPartnerStudentName VARCHAR,
+    referenzfach VARCHAR,
+    updatedReferenzfach VARCHAR,
+    bezugsfach VARCHAR,
+    updatedBezugsfach VARCHAR,
+    examiner VARCHAR,
+    updatedExaminer VARCHAR,
+    thema VARCHAR,
+    updatedThema VARCHAR,
+    problemQuestion VARCHAR,
+    updatedProblemQuestion VARCHAR,
+    presentationForm VARCHAR,
+    updatedPresentationForm VARCHAR,
+    genehmigt BOOLEAN,
+    ablehnungsgrund VARCHAR,
+    studentID INTEGER
+);
+
+INSERT INTO abitur_temp (id, art, partnerStudentName, updatedPartnerStudentName, referenzfach, updatedReferenzfach, bezugsfach, updatedBezugsfach, examiner, updatedExaminer, thema, updatedThema, problemQuestion, updatedProblemQuestion, presentationForm, updatedPresentationForm, genehmigt, ablehnungsgrund, studentID)
+SELECT id, art, partnerStudentName, updatedPartnerStudentName, referenzfach, updatedReferenzfach, bezugsfach, updatedBezugsfach, examiner, updatedExaminer, thema, updatedThema, problemQuestion, updatedProblemQuestion, presentationForm, updatedPresentationForm, genehmigt, ablehnungsgrund, studentID FROM abiturpruefungen;
+DROP TABLE abiturpruefungen;
+ALTER TABLE abitur_temp RENAME TO abiturpruefungen;

--- a/backend/migrations/sqls/20211201142913-tutorHinzufuegenAbitur-up.sql
+++ b/backend/migrations/sqls/20211201142913-tutorHinzufuegenAbitur-up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE abiturpruefungen ADD COLUMN tutor VARCHAR;
+ALTER TABLE abiturpruefungen ADD COLUMN updatedTutor VARCHAR;
+ALTER TABLE abiturpruefungen ADD COLUMN firstSubmissionDate DATETIME;
+ALTER TABLE abiturpruefungen ADD COLUMN finalSubmissionDate DATETIME;

--- a/backend/src/routing/controllers/api/Abitur.ts
+++ b/backend/src/routing/controllers/api/Abitur.ts
@@ -41,6 +41,7 @@ export default class Abitur {
         const studentId = await getStudentId(req, res);
         if (studentId === -1) return;
 
+        const { submitNumber } = req.body;
         let sql = 'SELECT id FROM abiturpruefungen WHERE studentID = ?';
         getFirstResult(sql, [studentId], (obj, err) => {
             if (err) {
@@ -50,6 +51,8 @@ export default class Abitur {
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore
                     updateUpdateColumns(obj.id);
+                } else if (submitNumber === 2) {
+                    setUpdateColumns();
                 } else {
                     insertFirstSubmission();
                 }
@@ -57,7 +60,7 @@ export default class Abitur {
         });
 
         const buildSetString = (args: (string|number)[]):string => {
-            const {updatedExaminer, updatedBezugsfach, updatedPartnerStudentName, updatedReferenzfach, updatedTopicArea, problemQuestion, updatedProblemQuestion, presentationForm, updatedPresentationForm} = req.body;
+            const {updatedExaminer, updatedBezugsfach, updatedPartnerStudentName, updatedReferenzfach, updatedTopicArea, problemQuestion, updatedProblemQuestion, presentationForm, updatedPresentationForm, updatedTutor} = req.body;
             let setString = '';
             setString += ' updatedExaminer = ?'; args.push(updatedExaminer ? updatedExaminer : null);
             setString += ', updatedBezugsfach = ?'; args.push(updatedBezugsfach ? updatedBezugsfach : null);
@@ -66,6 +69,7 @@ export default class Abitur {
             setString += ', updatedThema = ?'; args.push(updatedTopicArea ? updatedTopicArea : null);
             setString += ', updatedProblemQuestion = ?'; args.push(updatedProblemQuestion ? updatedProblemQuestion : null);
             setString += ', updatedPresentationForm = ?'; args.push(updatedPresentationForm ? updatedPresentationForm : null);
+            setString += ', updatedTutor = ?'; args.push(updatedTutor ? updatedTutor : null);
             if (problemQuestion) { setString += ', problemQuestion = ?'; args.push(problemQuestion); }
             if (presentationForm) { setString += ', presentationForm = ?'; args.push(presentationForm); }
             return setString;
@@ -74,15 +78,23 @@ export default class Abitur {
         const updateUpdateColumns = (id: number) => {
             const args: (string | number)[] = [];
             const setString = buildSetString(args);
-            sql = 'UPDATE abiturpruefungen SET' + setString +' WHERE id = ?';
-            args.push(id);
+            const { submitDate } = req.body;
+            sql = 'UPDATE abiturpruefungen SET' + setString +', finalSubmissionDate = ? WHERE id = ?';
+            args.push(submitDate, id);
             updateData(sql, args, defaultUpdateCallback(res));
         };
 
+        const setUpdateColumns = () => {
+            const {updatedExaminer, updatedBezugsfach, updatedPartnerStudentName, updatedReferenzfach, updatedTopicArea, problemQuestion, presentationForm, updatedTutor, examType, submitDate} = req.body;
+            sql = 'INSERT INTO abiturpruefungen (updatedExaminer, updatedBezugsfach, updatedPartnerStudentName, updatedReferenzfach, updatedThema, problemQuestion, presentationForm, updatedTutor, art, finalSubmissionDate, studentID) VALUES (?,?,?,?,?,?,?,?,?,?,?)';
+            const args = [updatedExaminer, updatedBezugsfach, updatedPartnerStudentName, updatedReferenzfach, updatedTopicArea, problemQuestion, presentationForm, updatedTutor, examType, submitDate, studentId];
+            insertData(sql, args, defaultInsertCallback(res));
+        };
+
         const insertFirstSubmission = () => {
-            const {examiner, examType, bezugsfach, partnerStudentName, referenzfach, topicArea} = req.body;
-            sql = 'INSERT INTO abiturpruefungen (examiner, art, bezugsfach, partnerStudentName, referenzfach, thema, studentID) VALUES (?,?,?,?,?,?,?)';
-            insertData(sql, [examiner, examType, bezugsfach, partnerStudentName, referenzfach, topicArea, studentId], defaultInsertCallback(res));
+            const {examiner, examType, bezugsfach, partnerStudentName, referenzfach, topicArea, tutor, submitDate} = req.body;
+            sql = 'INSERT INTO abiturpruefungen (examiner, art, bezugsfach, partnerStudentName, referenzfach, thema, studentID, tutor, firstSubmissionDate) VALUES (?,?,?,?,?,?,?,?,?)';
+            insertData(sql, [examiner, examType, bezugsfach, partnerStudentName, referenzfach, topicArea, studentId, tutor, submitDate], defaultInsertCallback(res));
         };
     }
 
@@ -116,7 +128,11 @@ export default class Abitur {
                 updatedPresentationForm,
                 genehmigt AS approved,
                 nutzer.name AS studentName,
-                studentID AS studentId
+                studentID AS studentId,
+                tutor,
+                updatedTutor,
+                firstSubmissionDate,
+                finalSubmissionDate
             FROM abiturpruefungen, nutzer
             WHERE studentID IS nutzer.id;
             `;
@@ -144,7 +160,9 @@ export default class Abitur {
                 presentationForm,
                 updatedPresentationForm,
                 genehmigt AS approved,
-                ablehnungsgrund AS rejectionReason
+                ablehnungsgrund AS rejectionReason,
+                tutor,
+                updatedTutor
             FROM abiturpruefungen, nutzer
             WHERE studentID IS nutzer.id AND studentID = ?;
             `;
@@ -155,10 +173,10 @@ export default class Abitur {
         if (rejectWhenValidationsFail(req, res)) return;
         const examId = req.params.examId;
         const args : Array<number|string> = [];
-        const { examType, updatedPartnerStudentName, updatedReferenzfach, updatedBezugsfach, updatedExaminer, updatedTopicArea, updatedProblemQuestion, updatedPresentationForm } = req.body;
+        const { examType, updatedPartnerStudentName, updatedReferenzfach, updatedBezugsfach, updatedExaminer, updatedTopicArea, updatedProblemQuestion, updatedPresentationForm, updatedTutor } = req.body;
         const art = examType;
         const updatedThema = updatedTopicArea;
-        const setString = Abitur.addToSetStringWhenDefined({updatedPartnerStudentName, updatedReferenzfach, updatedBezugsfach, updatedExaminer, updatedThema, updatedProblemQuestion, updatedPresentationForm, art }, args);
+        const setString = Abitur.addToSetStringWhenDefined({updatedPartnerStudentName, updatedReferenzfach, updatedBezugsfach, updatedExaminer, updatedThema, updatedProblemQuestion, updatedPresentationForm, art, updatedTutor }, args);
         const sql = 'UPDATE abiturpruefungen SET' +setString + ' WHERE id = ?';
         args.push(examId);
         updateData(sql, args, defaultUpdateCallback(res));

--- a/backend/src/routing/validators/api/abitur.ts
+++ b/backend/src/routing/validators/api/abitur.ts
@@ -17,7 +17,11 @@ export default class AbiturValidators {
         AbiturValidators.isOptionalString('updatedProblemQuestion'),
         AbiturValidators.isOptionalString('presentationForm'),
         AbiturValidators.isOptionalString('updatedPresentationForm'),
+        AbiturValidators.isOptionalString('tutor'),
+        AbiturValidators.isOptionalString('updatedTutor'),
         body('examType').isString().isIn(['BLL', 'PP']).optional(),
+        body('submitNumber').isInt().isIn([1,2]),
+        body('submitDate').isISO8601(),
     ];
     static POSTsetApprovalState = [
         body('examId').isInt(),
@@ -35,6 +39,7 @@ export default class AbiturValidators {
         AbiturValidators.isOptionalString('updatedTopicArea'),
         AbiturValidators.isOptionalString('updatedProblemQuestion'),
         AbiturValidators.isOptionalString('updatedPresentationForm'),
+        AbiturValidators.isOptionalString('updatedTutor'),
         body('examType').isString().isIn(['BLL', 'PP'])
     ];
 }

--- a/dokumentation/db/Kant-Schnittstellen.txt
+++ b/dokumentation/db/Kant-Schnittstellen.txt
@@ -59,7 +59,7 @@ api/components/getTransitionDatesOfAll (GET)
 (Alle Parameter sollten optional sein, da die Schnittstelle auch für Änderungen genutzt wird, und bei Änderungen möglicherweise nur ein Parameter (der neue) übergeben wird)
 /api/abitur/applyForTopic (POST) (Nur für Schüler)
 	{String examType (one of ['PP', 'BLL']), partnerStudentName, String updatedPartnerStudentName,
-	String referenzfach, String updatedReferenzfach, String bezugsfach, String updatedBezugsfach, String tutor, String examiner, String updatedExaminer,
+	String referenzfach, String updatedReferenzfach, String bezugsfach, String updatedBezugsfach, String tutor, String updatedTutor, String examiner, String updatedExaminer,
 	String topicArea, String updatedTopicArea, String problemQuestion, String updatedProblemQuestion, String presentationForm, String updatedPresentationForm,
 	int submitNumber, Date submitDate
 	}
@@ -82,7 +82,7 @@ api/components/getTransitionDatesOfAll (GET)
 		String updatedPartnerStudentName, String referenzfach, String updatedReferenzfach, String bezugsfach, String updatedBezugsfach, String tutor,
 		String updatedTutor, String examiner, String updatedExaminer, String topicArea, String updatedTopicArea, String problemQuestion,
 		String updatedProblemQuestion, String presentationForm, 
-		String updatedPresentationForm, Boolean approved, String studentName, Int studentId, String initialSubmitDate, String finalSubmitDate}
+		String updatedPresentationForm, Boolean approved, String studentName, Int studentId, String firstSubmissionDate, String finalSubmissionDate}
 	]}
 
 3 Schüler sieht daten zu seiner Prüfung ein


### PR DESCRIPTION
Abitur.ts:
- tutor und updatedTutor ergänzen
- setUpdateColumns für den Fall dass ein Schüler das erste mal in Schritt 2 Einreicht
- submissionDates setzen

abitur.ts:
- submitNumber und submitDate verpflichtend
- tutor und updateTutor ergänzt

Kant-Schnittstellen.txt:
- submitdates umbenannt um an die DB angepasst zu sein
- updatedTutor ergänzt